### PR TITLE
feat: Implementa coleta de cocos nas ilhas

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,23 @@
             background: #000;
         }
         canvas { display: block; } /* Adicionado para garantir */
+
+        #coconut-counter {
+            position: absolute; /* Para posicionar sobre a cena */
+            top: 10px;
+            left: 10px;
+            padding: 10px;
+            background-color: rgba(0, 0, 0, 0.5); /* Fundo semitransparente */
+            color: white;
+            font-family: Arial, sans-serif;
+            font-size: 18px;
+            border-radius: 5px;
+            z-index: 100; /* Para garantir que fique na frente do canvas */
+        }
     </style>
 </head>
 <body>
+    <div id="coconut-counter">Cocos: 0</div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.min.js"></script>
     <script>
@@ -22,34 +36,38 @@
         renderer.setSize(window.innerWidth, window.innerHeight);
         document.body.appendChild(renderer.domElement);
 
-        
+        const COCONUT_COLLECTION_RADIUS = 10;
+        let coconutsCollected = 0;
+        const coconutCounterElement = document.getElementById('coconut-counter');
+
+
 
         // Configuração inicial da câmera
         camera.position.set(0, 100, 200);
         camera.lookAt(0, 0, 0);
 
 
-       
-        
+
+
 
         // Fundo totalmente preto para contraste
         scene.background = new THREE.Color('#89d4f5');
-        
+
         // Lighting
         const ambientLight = new THREE.AmbientLight(0xffffff, 0.8);
         scene.add(ambientLight);
-        
+
         const directionalLight = new THREE.DirectionalLight(0xffffff, 1);
         directionalLight.position.set(100, 100, 50);
         scene.add(directionalLight);
 
         // Grid Helper para referência visual
-       
+
         // Criação do mar usando BufferGeometry
         const width = 4000;
         const height = 4000;
         const segments = 128;
-        
+
         const geometry = new THREE.BufferGeometry();
         const vertices = [];
         const indices = [];
@@ -97,7 +115,7 @@
 
         // Criação das praias
         const beachGroup = new THREE.Group();
-        
+
         // Material da praia
         const beachMaterial = new THREE.MeshStandardMaterial({
             color: '#f0ec81',
@@ -110,11 +128,11 @@
         function createBeachSection(width, length, posX, posZ, rotationY) {
             const geometry = new THREE.BufferGeometry();
             const segments = 50;  // número de segmentos em cada direção
-            
+
             // Criar vértices em grade
             const vertices = [];
             const indices = [];
-            
+
             // Criar vértices
             for(let i = 0; i <= segments; i++) {
                 for(let j = 0; j <= segments; j++) {
@@ -123,7 +141,7 @@
                     vertices.push(x, 0, z);
                 }
             }
-            
+
             // Criar índices para triângulos
             for(let i = 0; i < segments; i++) {
                 for(let j = 0; j < segments; j++) {
@@ -131,27 +149,27 @@
                     const b = a + 1;
                     const c = a + (segments + 1);
                     const d = c + 1;
-                    
+
                     indices.push(a, b, c);
                     indices.push(b, d, c);
                 }
             }
-            
+
             geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
             geometry.setIndex(indices);
-            
+
             // Criar a malha
             const beach = new THREE.Mesh(geometry, beachMaterial);
             beach.rotation.x = -Math.PI * 2; // Mesma rotação do mar
             beach.rotation.y = rotationY;
             beach.position.set(posX, 0, posZ);
-            
+
             // Modificar os vértices para criar inclinação
             const positions = beach.geometry.attributes.position.array;
             for (let i = 0; i < positions.length; i += 3) {
                 const x = positions[i];
                 const z = positions[i + 2];
-                
+
                 // Calcular distância normalizada da água
                 let distFromWater;
                 if (rotationY === 0) { // Praia Sul
@@ -159,21 +177,21 @@
                 } else { // Praias Leste/Oeste
                     distFromWater = (x + width/2) / width;
                 }
-                
+
                 // Criar elevação suave
                 positions[i + 1] = Math.pow(distFromWater, 1.5) * 20;
             }
-            
+
             geometry.attributes.position.needsUpdate = true;
             geometry.computeVertexNormals();
-            
+
             return beach;
         }
 
         // Criar as três praias com dimensões ajustadas
         const beachWidth = width;    // Largura igual ao mar
         const beachLength = 400;     // Profundidade da praia
-        
+
         // Praia Sul - alinhada com a borda sul do mar
         const southBeach = createBeachSection(beachWidth, beachLength, 0, height/2, 0);
         beachGroup.add(southBeach);
@@ -191,7 +209,7 @@
         // Criação de ilhas aleatórias
         const numberOfIslands = 20; // Quantidade de ilhas
         const islandGroup = new THREE.Group();
-        
+
         for (let i = 0; i < numberOfIslands; i++) {
             // Criar ilha com forma irregular
             const islandGeometry = new THREE.CylinderGeometry(
@@ -202,26 +220,27 @@
                 1,
                 false
             );
-            
+
             // Material da ilha com cor de areia
             const islandMaterial = new THREE.MeshStandardMaterial({
                 color: 0xd2b48c,
                 roughness: 0.8,
                 metalness: 0
             });
-            
+
             const island = new THREE.Mesh(islandGeometry, islandMaterial);
-            
+
             // Posição aleatória dentro dos limites do mar
             island.position.set(
                 (Math.random() - 0.5) * 3000, // X: espalhadas pelo mar
                 1,                            // Y: ligeiramente acima do nível do mar
                 (Math.random() - 0.5) * 3000  // Z: espalhadas pelo mar
             );
-            
+
             // Rotação aleatória para variedade
             island.rotation.y = Math.random() * Math.PI * 2;
-            
+            island.coconuts = []; // Array para armazenar cocos da ilha
+
             // Adicionar algumas palmeiras em cada ilha
             const numberOfTrees = Math.floor(Math.random() * 3) + 1;
             for (let j = 0; j < numberOfTrees; j++) {
@@ -232,7 +251,7 @@
                     roughness: 0.8
                 });
                 const trunk = new THREE.Mesh(trunkGeometry, trunkMaterial);
-                
+
                 // Folhas da palmeira
                 const leavesGeometry = new THREE.ConeGeometry(8, 4, 8);
                 const leavesMaterial = new THREE.MeshStandardMaterial({
@@ -242,12 +261,12 @@
                 const leaves = new THREE.Mesh(leavesGeometry, leavesMaterial);
                 leaves.position.y = 10;
                 leaves.rotation.x = Math.PI * 0.1;
-                
+
                 // Grupo da palmeira
                 const tree = new THREE.Group();
                 tree.add(trunk);
                 tree.add(leaves);
-                
+
                 // Posição aleatória na ilha
                 const angle = (Math.PI * 2 * j) / numberOfTrees;
                 const radius = Math.random() * 3 + 2;
@@ -258,13 +277,38 @@
                 );
                 tree.rotation.y = Math.random() * Math.PI * 2;
                 tree.scale.set(0.8, 0.8, 0.8);
-                
+
                 island.add(tree);
             }
-            
+
+            // Adicionar cocos à ilha
+            const coconutGeometry = new THREE.SphereGeometry(0.5, 8, 8); // Raio pequeno, 8x8 segmentos
+            const coconutMaterial = new THREE.MeshStandardMaterial({ color: 0x8B4513 }); // Marrom
+            const numberOfCoconuts = Math.floor(Math.random() * 2) + 2; // 2 a 3 cocos
+
+            for (let k = 0; k < numberOfCoconuts; k++) {
+                const coconut = new THREE.Mesh(coconutGeometry, coconutMaterial);
+
+                const islandRadius = islandGeometry.parameters.radiusTop;
+                const angle = Math.random() * Math.PI * 2;
+                const radiusOnIsland = Math.random() * (islandRadius * 0.8);
+
+                const yPosition = (islandGeometry.parameters.height / 2) + 0.25; // Centro do coco = topo da ilha + raio do coco
+
+                coconut.position.set(
+                    Math.cos(angle) * radiusOnIsland,
+                    yPosition,
+                    Math.sin(angle) * radiusOnIsland
+                );
+
+                coconut.castShadow = true;
+                island.add(coconut);
+                island.coconuts.push(coconut);
+            }
+
             islandGroup.add(island);
         }
-        
+
         scene.add(islandGroup);
 
         // Controles orbitais
@@ -308,7 +352,7 @@
                 const clampedDeltaTime = Math.min(deltaTime, 0.1);
                 this.life -= clampedDeltaTime * 0.3;
                 //this.position.y += clampedDeltaTime ;
-                
+
                 // Atualizar opacidade baseada na vida
                 this.mesh.material.opacity = (this.life / 1.0) * 0.5;
                 this.mesh.position.copy(this.position);
@@ -362,12 +406,46 @@
             rotationSpeed: 0.03 // Velocidade de rotação
         };
 
-       
+
 
         // Sistema de input
         const keys = {};
         document.addEventListener('keydown', e => keys[e.code] = true);
         document.addEventListener('keyup', e => keys[e.code] = false);
+
+        document.addEventListener('keydown', e => {
+            if (e.code === 'KeyE') {
+                const boatPosition = boatGroup.position;
+                let collectedCoco = false; // Flag para coletar apenas um coco por vez
+
+                for (const island of islandGroup.children) {
+                    if (island.coconuts && island.coconuts.length > 0) {
+                        for (let i = 0; i < island.coconuts.length; i++) {
+                            const coconut = island.coconuts[i];
+                            const coconutWorldPosition = new THREE.Vector3();
+                            coconut.getWorldPosition(coconutWorldPosition);
+
+                            const distanceToCoconut = boatPosition.distanceTo(coconutWorldPosition);
+
+                            if (distanceToCoconut <= COCONUT_COLLECTION_RADIUS) {
+                                coconutsCollected++;
+                                // console.log("Coco coletado! Total:", coconutsCollected);
+                                coconutCounterElement.textContent = "Cocos: " + coconutsCollected;
+
+                                island.remove(coconut); // Remove da cena (island é o pai)
+                                island.coconuts.splice(i, 1); // Remove do array da ilha
+
+                                collectedCoco = true;
+                                break; // Sai do loop interno (cocos da ilha atual)
+                            }
+                        }
+                    }
+                    if (collectedCoco) {
+                        break; // Sai do loop externo (ilhas)
+                    }
+                }
+            }
+        });
 
         // --- Função Animate ---
         function animate() {
@@ -383,7 +461,7 @@
             for (let i = 0; i < positions.length; i += 3) {
                 const x = positions[i];
                 const z = positions[i + 2];
-                positions[i + 1] = 
+                positions[i + 1] =
                     Math.sin(x * 0.04 + time) * 2.0 +
                     Math.sin(z * 0.03 + time) * 2.0 +
                     Math.sin((x + z) * 0.01 + time) * 1.0;
@@ -429,6 +507,24 @@
             // Aplicar estado ao objeto visual boatGroup
             boatGroup.position.copy(boatState.position);
             boatGroup.rotation.y = boatState.rotation; // Aplica a rotação Y
+
+            // --- Detecção de Proximidade com Cocos ---
+            const boatPosition = boatGroup.position;
+            islandGroup.children.forEach(island => {
+                if (island.coconuts && island.coconuts.length > 0) {
+                    island.coconuts.forEach(coconut => {
+                        const coconutWorldPosition = new THREE.Vector3();
+                        coconut.getWorldPosition(coconutWorldPosition); // Obtém a posição mundial do coco
+
+                        const distanceToCoconut = boatPosition.distanceTo(coconutWorldPosition);
+
+                        if (distanceToCoconut <= COCONUT_COLLECTION_RADIUS) {
+                            // console.log("Barco próximo ao coco:", coconut.uuid, "da ilha:", island.uuid, "Distância:", distanceToCoconut);
+                            // Aqui futuramente poderia adicionar lógica para "coletar" o coco
+                        }
+                    });
+                }
+            });
 
             // --- Emissão de Partículas ---
             const isMovingForward = boatState.speed > 0.1;


### PR DESCRIPTION
Adiciona a funcionalidade de coletar cocos às ilhas do jogo Marazul.

Principais mudanças:
- Adiciona objetos visuais (esferas marrons) para representar os cocos próximos às palmeiras em cada ilha.
- Implementa a lógica para detectar a proximidade do seu barco aos cocos.
- Permite que você colete cocos pressionando a tecla "E" quando o barco está próximo o suficiente.
- Cocos coletados são removidos da cena e de suas respectivas ilhas.
- Adiciona um contador visual na sua interface (canto superior esquerdo) que exibe a quantidade de cocos coletados.
- Ajusta o raio de coleta para 10 unidades para uma jogabilidade mais precisa.